### PR TITLE
[Feature] Add MCP

### DIFF
--- a/cmd/mcp/main.go
+++ b/cmd/mcp/main.go
@@ -35,13 +35,13 @@ func main() {
 		if err != nil {
 			return nil, err
 		}
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("http error: %s", resp.Status)
+		}
 		defer resp.Body.Close()
 		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return nil, err
-		}
-		if resp.StatusCode != http.StatusOK {
-			return nil, fmt.Errorf("http error: %s", resp.Status)
 		}
 		var payload WeatherAlert
 		if err := json.Unmarshal(body, &payload); err != nil {

--- a/cmd/mcp/main.go
+++ b/cmd/mcp/main.go
@@ -40,6 +40,9 @@ func main() {
 		if err != nil {
 			return nil, err
 		}
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("http error: %s", resp.Status)
+		}
 		var payload WeatherAlert
 		if err := json.Unmarshal(body, &payload); err != nil {
 			return nil, err

--- a/cmd/mcp/main.go
+++ b/cmd/mcp/main.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+func main() {
+	s := server.NewMCPServer(
+		"Redd MCP Server",
+		"1.0.0",
+		server.WithResourceCapabilities(true, true),
+		server.WithLogging(),
+	)
+
+	getAlerts := mcp.NewTool(
+		"get_alerts",
+		mcp.WithDescription("Get weather alerts for a US state."),
+		mcp.WithString(
+			"state",
+			mcp.Required(),
+			mcp.Description("The US state to get alerts for.")),
+	)
+	s.AddTool(getAlerts, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		state := request.Params.Arguments["state"].(string)
+		url := fmt.Sprintf("https://api.weather.gov/alerts/active/area/%s", state)
+		resp, err := http.Get(url)
+		if err != nil {
+			return nil, err
+		}
+		defer resp.Body.Close()
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, err
+		}
+		var payload WeatherAlert
+		if err := json.Unmarshal(body, &payload); err != nil {
+			return nil, err
+		}
+		if len(payload.Features) == 0 {
+			return mcp.NewToolResultText("No active alerts for this state."), nil
+		}
+		var alerts []string
+		for _, feature := range payload.Features {
+			alerts = append(alerts, fmt.Sprintf("Event: %s\nArea: %s\nSeverity: %s\nDescription: %s\nInstruction: %s\n",
+				feature.Properties.Event,
+				feature.Properties.AreaDesc,
+				feature.Properties.Severity,
+				feature.Properties.Description,
+				feature.Properties.Instruction))
+		}
+		return mcp.NewToolResultText(strings.Join(alerts, "\n--\n")), nil
+	})
+
+	if err := server.ServeStdio(s); err != nil {
+		fmt.Printf("Server error: %v\n", err)
+	}
+}
+
+type WeatherAlert struct {
+	Features []WeatherAlertFeature `json:"features"`
+}
+
+type WeatherAlertFeature struct {
+	Properties WeatherAlertFeatureProperty `json:"properties"`
+}
+
+type WeatherAlertFeatureProperty struct {
+	Event       string `json:"event"`
+	AreaDesc    string `json:"areaDesc"`
+	Severity    string `json:"severity"`
+	Description string `json:"description"`
+	Instruction string `json:"instruction"`
+}

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.28.1
 	github.com/gin-contrib/cors v1.7.4
 	github.com/gin-gonic/gin v1.10.0
+	github.com/mark3labs/mcp-go v0.18.0
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/viper v1.20.1
 	github.com/stretchr/testify v1.10.0
@@ -38,6 +39,7 @@ require (
 	github.com/go-playground/validator/v10 v10.26.0 // indirect
 	github.com/go-viper/mapstructure/v2 v2.2.1 // indirect
 	github.com/goccy/go-json v0.10.5 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.10 // indirect
@@ -55,6 +57,7 @@ require (
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.12 // indirect
+	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/arch v0.15.0 // indirect
 	golang.org/x/crypto v0.36.0 // indirect


### PR DESCRIPTION
This pull request includes significant changes to the `cmd/mcp/main.go` file to add a new feature for fetching weather alerts, as well as updates to the `go.mod` file to include new dependencies required for this feature.

### New Feature Implementation:

* Added a new main function in `cmd/mcp/main.go` to create and start an MCP server with a new tool for fetching weather alerts for a specified US state. This includes defining the `WeatherAlert`, `WeatherAlertFeature`, and `WeatherAlertFeatureProperty` types to parse the response from the weather API.

### Dependency Updates:

* Added `github.com/mark3labs/mcp-go v0.18.0` to the `require` section in `go.mod` to support the new MCP server and tool functionalities.
* Added `github.com/google/uuid v1.6.0` as an indirect dependency in `go.mod` for unique identifier generation.
* Added `github.com/yosida95/uritemplate/v3 v3.0.2` as an indirect dependency in `go.mod` for URI template parsing.